### PR TITLE
Update README.md to replace dead links on Bell Labs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ total    6
 
 ## Documentation
 The manuals for 1st Edition UNIX are available here:
-<https://www.bell-labs.com/usr/dmr/www/1stEdman.html>,
+<https://web.archive.org/web/20250114151916/https://www.bell-labs.com/usr/dmr/www/1stEdman.html>,
 <https://www.tuhs.org/Archive/Distributions/Research/Dennis_v1/UNIX_ProgrammersManual_Nov71.pdf>, and
 <https://man.cat-v.org/unix-1st/>.
 
@@ -91,7 +91,7 @@ The C compiler from 2nd Edition UNIX has been installed and is operational.
 However, it supports a very early dialect of C. The most relevant reference for
 this version of the language is as follows, although it may be approximately
 two years more advanced than the dialect in question:
-<https://www.bell-labs.com/usr/dmr/www/cman74.pdf>
+<https://web.archive.org/web/20240425202413/https://www.bell-labs.com/usr/dmr/www/cman74.pdf>
 
 The userland binaries originate from a period between the 1st and 2nd Editions
 of UNIX. The manuals from the 2nd Edition may also be useful:

--- a/notes/machine.txt
+++ b/notes/machine.txt
@@ -128,12 +128,12 @@ hardware at all. "
 Digital in Maynard to talk about it; in particular, we had the specs 
 for the floating-point instructions it supported. So the system 
 described here included a simulator for the instructions (fptrap(III))."
-   - https://www.bell-labs.com/usr/dmr/www/1stEdman.html
+   - https://web.archive.org/web/20250114151916/https://www.bell-labs.com/usr/dmr/www/1stEdman.html
      (describing nov 3, 1971 manuals)
 
 -------------------------------------
 section VII pg 5 has "boot procedures" section:
-https://www.bell-labs.com/usr/dmr/www/man71.pdf
+https://web.archive.org/web/20241203033024/https://www.bell-labs.com/usr/dmr/www/man71.pdf
 
 ------------------------------------
 http://en.wikipedia.org/wiki/PDP-11#PDP-11_instruction_repertoire

--- a/src/c/README.md
+++ b/src/c/README.md
@@ -1,7 +1,7 @@
 # Early C compiler
 
 This directory contains the last1120c C compiler, as described by Dennis Ritchie
-on his web page: <https://www.bell-labs.com/usr/dmr/www/primevalC.html>.
+on his web page: <https://web.archive.org/web/20250121035636/https://www.bell-labs.com/usr/dmr/www/primevalC.html>.
 
 You can use the Apout emulator and the C compiler from the s2 tape to recompile
 the last1120c compiler. After installing the new compiler binaries, last1120c


### PR DESCRIPTION
The C reference manual is a dead link on Bell Labs' website. Perhaps we should replace it with the version on archive.org. 